### PR TITLE
fix: regex range out of order

### DIFF
--- a/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
+++ b/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
@@ -801,7 +801,7 @@ The output of `node create-mint-account.js` should include the base-58 represent
 
 ```js
 const terminalOutput = await __helpers.getTerminalOutput();
-assert.match(terminalOutput, /[a-Z0-9]{44}/);
+assert.match(terminalOutput, /[A-z0-9]{44}/);
 ```
 
 The validator should be running at `http://localhost:8899`.
@@ -1273,7 +1273,7 @@ The output of `node create-token-account.js` should include the base-58 represen
 
 ```js
 const terminalOutput = await __helpers.getTerminalOutput();
-assert.match(terminalOutput, /[a-Z0-9]{44}/);
+assert.match(terminalOutput, /[A-z0-9]{44}/);
 ```
 
 The validator should be running at `http://localhost:8899`.


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
- Wrong order in the character class was causing error
```
🔴 ERROR:  2023-05-02 02:59:24 Test #2: SyntaxError: Invalid regular expression: /[a-Z0-9]{44}/: Range out of order in character class
    at file:///workspace/solana-curriculum/node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/test.js:94:57
    at Array.map (<anonymous>)
    at runTests (file:///workspace/solana-curriculum/node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/test.js:80:43)
    at async FSWatcher.<anonymous> (file:///workspace/solana-curriculum/node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/hot-reload.js:51:9)
```
- Let me know if version bump is desired