### PR TITLE
fix: BigInt comparison

### DIFF
--- a/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
+++ b/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
@@ -2699,7 +2699,7 @@ const { Connection } = await import('@solana/web3.js');
 const connection = new Connection('http://localhost:8899');
 
 const mint = await getMint(connection, mintAddress);
-assert.isTrue(mint.supply >= 3_000_000_000, '`mint.supply` should be at least `3_000_000_000`');
+assert.isAtLeast(Number(mint.supply), 3_000_000_000);
 ```
 
 The validator should be running at `http://localhost:8899`.

--- a/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
+++ b/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
@@ -2699,7 +2699,7 @@ const { Connection } = await import('@solana/web3.js');
 const connection = new Connection('http://localhost:8899');
 
 const mint = await getMint(connection, mintAddress);
-assert.isAtLeast(mint.supply, 3_000_000_000);
+assert.isTrue(mint.supply >= 3_000_000_000, '`mint.supply` should be at least `3_000_000_000`');
 ```
 
 The validator should be running at `http://localhost:8899`.


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
`assert.isAtLeast` appears to not like `BigInt`, which is the type of `mint.supply`. I haven't copied the exact error, but the gist was that number or date was expected.
