### PR TITLE
fix: escape special character

### DIFF
--- a/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
+++ b/curriculum/locales/english/learn-solanas-token-program-by-minting-a-fungible-token.md
@@ -3685,7 +3685,7 @@ You should run the `transfer.js` script.
 const { tokenAccount } = await __helpers.importSansCache(
   '../learn-solanas-token-program-by-minting-a-fungible-token/utils.js'
 );
-const commandRe = new RegExp(`node transfer.js ${tokenAccount.toBase58()} \d+`);
+const commandRe = new RegExp(`node transfer.js ${tokenAccount.toBase58()} \\d+`);
 const lastCommand = await __helpers.getLastCommand();
 assert.match(
   lastCommand,


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
- Escaped `\` in string, as `RegExp` constructor is used. Otherwise regex expects literal `d` at the end.