### PR TITLE
fix: ensure `readFile` is awaited

### DIFF
--- a/curriculum/locales/english/learn-the-metaplex-sdk-by-minting-an-nft.md
+++ b/curriculum/locales/english/learn-the-metaplex-sdk-by-minting-an-nft.md
@@ -1367,7 +1367,7 @@ const minifiedCode = babelisedCode.generateCode(variableDeclaration, {
 });
 assert.match(
   minifiedCode,
-  /imageBuffer=(await )?(readFile|readFileSync|read)\(('|"|`)(\.\/)?assets\/pic\.png\3\)/
+  /imageBuffer=(await readFile|readFileSync|read)\(('|"|`)(\.\/)?assets\/pic\.png\2\)/
 );
 ```
 


### PR DESCRIPTION
Checklist:

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

---
- I missed adding `await`, when using `readFile`, at lesson `24`. It revealed itself later at lesson `31`.