### PR TITLE
fix(1.0.2): adjust cli versioning

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,11 +1,11 @@
-FROM gitpod/workspace-full:2023-08-29-11-00-25
+FROM gitpod/workspace-full:2024-05-22-07-25-51
 
 ARG REPO_NAME=solana-curriculum
 ARG HOMEDIR=/workspace/$REPO_NAME
 
 WORKDIR ${HOMEDIR}
 
-RUN bash -c 'VERSION="18" \
+RUN bash -c 'VERSION="20" \
     && source $HOME/.nvm/nvm.sh && nvm install $VERSION \
     && nvm use $VERSION && nvm alias default $VERSION'
 
@@ -14,10 +14,10 @@ RUN echo "nvm use default &>/dev/null" >> ~/.bashrc.d/51-nvm-fix
 RUN sudo apt-get update && sudo apt-get upgrade -y
 
 # Solana
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.11/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.18/install)"
 # RUN wget https://github.com/solana-labs/solana/releases/download/v1.16.9/solana-release-x86_64-unknown-linux-gnu.tar.bz2
 # RUN tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
 # RUN cd solana-release/
 # ENV PATH="$PWD/bin:${PATH}"
 
-RUN npm i -g @coral-xyz/anchor-cli@0.28.0
+RUN npm i -g @coral-xyz/anchor-cli@0.30.0

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> \
 RUN sudo apt-get install -y curl git bash-completion man-db htop nano
 
 # Install Node LTS
-RUN curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash -
+RUN curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
 RUN sudo apt-get install -y nodejs
 
 # Rust
@@ -37,7 +37,7 @@ RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
 ENV PATH="/workspace/.cargo/bin:${PATH}"
 
 # Solana
-RUN sh -c "$(curl -sSfL https://release.solana.com/v1.16.11/install)"
+RUN sh -c "$(curl -sSfL https://release.solana.com/v1.17.18/install)"
 # RUN wget https://github.com/solana-labs/solana/releases/download/v1.16.9/solana-release-x86_64-unknown-linux-gnu.tar.bz2
 # RUN tar jxf solana-release-x86_64-unknown-linux-gnu.tar.bz2
 # RUN cd solana-release/
@@ -49,7 +49,7 @@ WORKDIR ${HOMEDIR}
 RUN mkdir ~/.npm-global
 RUN npm config set prefix '~/.npm-global'
 
-RUN npm install -g yarn @coral-xyz/anchor-cli@0.28.0
+RUN npm install -g yarn @coral-xyz/anchor-cli@0.30.0
 
 # Configure course-specific environment
 COPY . .

--- a/curriculum/locales/english/learn-how-to-set-up-solana-by-building-a-hello-world-smart-contract.md
+++ b/curriculum/locales/english/learn-how-to-set-up-solana-by-building-a-hello-world-smart-contract.md
@@ -34,57 +34,13 @@ You will be using the Solana CLI to:
 - Log useful information
 - Deploy your on-chain program
 
-Install the Solana CLI with:
+The Solana CLI can be installed with:
 
 ```bash
-sh -c "$(curl -sSfL https://release.solana.com/v1.14.7/install)"
+sh -c "$(curl -sSfL https://release.solana.com/v1.17.18/install)"
 ```
 
-### --tests--
-
-You should run the above bash command to install the Solana CLI.
-
-```js
-const lastCommand = await __helpers.getLastCommand();
-
-assert.match(
-  lastCommand,
-  /sh -c "\$\(curl -sSfL https:\/\/release\.solana\.com\/v1\.14\.7\/install\)"/
-);
-```
-
-## 3
-
-### --description--
-
-You will likely need to adjust the environment variable for your `PATH`, in order for you to use the `solana` alias.
-
-If prompted in the terminal, update your `PATH` environment variable to include the Solana programs.
-
-**Note:** You need to manually click the _Run Tests_ button.
-
-### --tests--
-
-You should copy the given PATH command into your terminal.
-
-```js
-const terminalOut = await __helpers.getTerminalOutput();
-const mat = terminalOut.match(/PATH=".*"/);
-if (mat) {
-  const lastCommand = await __helpers.getLastCommand();
-  assert.match(lastCommand, mat);
-}
-```
-
-## 4
-
-### --description--
-
-Confirm the Solana CLI is installed with:
-
-```bash
-solana --version
-```
+Solana is already installed in this environment. So, run `solana --version` to confirm it is installed.
 
 ### --tests--
 
@@ -96,7 +52,14 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana --version/);
 ```
 
-## 5
+The version should be printed to the console.
+
+```js
+const terminalOut = await __helpers.getTerminalOutput();
+assert.include(terminalOut, "1.17.18");
+```
+
+## 3
 
 ### --description--
 
@@ -117,7 +80,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana --help/);
 ```
 
-## 6
+## 4
 
 ### --description--
 
@@ -136,7 +99,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana config get/);
 ```
 
-## 7
+## 5
 
 ### --description--
 
@@ -163,7 +126,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana config set --url localhost/);
 ```
 
-## 8
+## 6
 
 ### --description--
 
@@ -178,7 +141,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana config get/);
 ```
 
-## 9
+## 7
 
 ### --description--
 
@@ -199,7 +162,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /cat ~\/\.config\/solana\/cli\/config.yml/);
 ```
 
-## 10
+## 8
 
 ### --description--
 
@@ -220,7 +183,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana-keygen new/);
 ```
 
-## 11
+## 9
 
 ### --description--
 
@@ -241,7 +204,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /cat ~\/\.config\/solana\/id\.json/);
 ```
 
-## 12
+## 10
 
 ### --description--
 
@@ -260,7 +223,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.match(lastCommand, /solana address/);
 ```
 
-## 13
+## 11
 
 ### --description--
 
@@ -293,7 +256,7 @@ try {
 }
 ```
 
-## 14
+## 12
 
 ### --description--
 
@@ -337,7 +300,7 @@ const terminalOut = await __helpers.getTerminalOutput();
 assert.match(terminalOut, /"result":/);
 ```
 
-## 15
+## 13
 
 ### --description--
 
@@ -375,7 +338,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.include(lastCommand, `solana balance ${accountAddress}`);
 ```
 
-## 16
+## 14
 
 ### --description--
 
@@ -425,7 +388,7 @@ const balance = stdout.trim()?.match(/\d+/)[0];
 assert.isAtLeast(Number(balance), 500000001);
 ```
 
-## 17
+## 15
 
 ### --description--
 
@@ -457,7 +420,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.include(lastCommand, `solana balance ${accountAddress}`);
 ```
 
-## 18
+## 16
 
 ### --description--
 
@@ -476,7 +439,7 @@ const file = await __helpers.getFile(
 assert.include(file, 'use solana_program;');
 ```
 
-## 19
+## 17
 
 ### --description--
 
@@ -496,7 +459,7 @@ const file = await __helpers.getFile(
 assert.match(file, /pub\s+fn\s+process_instruction\s*\(/s);
 ```
 
-## 20
+## 18
 
 ### --description--
 
@@ -541,7 +504,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /entrypoint!\(\s*process_instruction\s*\)/s);
 ```
 
-## 21
+## 19
 
 ### --description--
 
@@ -586,7 +549,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /msg!\(\s*"Hello World"\s*\)/s);
 ```
 
-## 22
+## 20
 
 ### --description--
 
@@ -609,7 +572,7 @@ assert.match(
 );
 ```
 
-## 23
+## 21
 
 ### --description--
 
@@ -656,7 +619,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /program_id\s*:\s*&Pubkey/s);
 ```
 
-## 24
+## 22
 
 ### --description--
 
@@ -703,7 +666,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /accounts\s*:\s*&\[\s*AccountInfo\s*\]/s);
 ```
 
-## 25
+## 23
 
 ### --description--
 
@@ -731,7 +694,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /instruction_data\s*:\s*&\[\s*u8\s*\]/s);
 ```
 
-## 26
+## 24
 
 ### --description--
 
@@ -776,7 +739,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /Ok\s*\(\s*\(\s*\)\s*\)/s);
 ```
 
-## 27
+## 25
 
 ### --description--
 
@@ -799,7 +762,7 @@ const cwd = wds.split('\n').filter(Boolean).pop();
 assert.match(cwd, /src\/program-rust\/?$/);
 ```
 
-## 28
+## 26
 
 ### --description--
 
@@ -826,7 +789,7 @@ const cwd = wds.split('\n').filter(Boolean).pop();
 assert.match(cwd, /src\/program-rust\/?$/);
 ```
 
-## 29
+## 27
 
 ### --description--
 
@@ -871,7 +834,7 @@ assert.match(
 );
 ```
 
-## 30
+## 28
 
 ### --description--
 
@@ -905,7 +868,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.include(lastCommand, 'solana program show');
 ```
 
-## 31
+## 29
 
 ### --description--
 
@@ -924,7 +887,7 @@ const temp = await __helpers.getTemp();
 assert.include(temp, 'Streaming transaction logs');
 ```
 
-## 32
+## 30
 
 ### --description--
 
@@ -969,7 +932,7 @@ assert.match(
 );
 ```
 
-## 33
+## 31
 
 ### --description--
 
@@ -993,7 +956,7 @@ assert.match(
 );
 ```
 
-## 34
+## 32
 
 ### --description--
 
@@ -1030,7 +993,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /\}\s*else\s*\{\s*msg!\s*\(/s);
 ```
 
-## 35
+## 33
 
 ### --description--
 
@@ -1055,7 +1018,7 @@ const someMatch = variants.some(r => file.match(r));
 assert.isTrue(someMatch, `Your code should match one of ${variants}`);
 ```
 
-## 36
+## 34
 
 ### --description--
 
@@ -1084,7 +1047,7 @@ assert.match(
 );
 ```
 
-## 37
+## 35
 
 ### --description--
 
@@ -1106,7 +1069,7 @@ assert.match(
 );
 ```
 
-## 38
+## 36
 
 ### --description--
 
@@ -1126,7 +1089,7 @@ assert.match(
 );
 ```
 
-## 39
+## 37
 
 ### --description--
 
@@ -1146,7 +1109,7 @@ assert.match(
 );
 ```
 
-## 40
+## 38
 
 ### --description--
 
@@ -1168,7 +1131,7 @@ assert.match(
 );
 ```
 
-## 41
+## 39
 
 ### --description--
 
@@ -1188,7 +1151,7 @@ assert.match(
 );
 ```
 
-## 42
+## 40
 
 ### --description--
 
@@ -1230,7 +1193,7 @@ const someMatch = variants.some(r => file.match(r));
 assert.isTrue(someMatch, `Your code should match one of ${variants}`);
 ```
 
-## 43
+## 41
 
 ### --description--
 
@@ -1265,7 +1228,7 @@ assert.match(
 );
 ```
 
-## 44
+## 42
 
 ### --description--
 
@@ -1282,7 +1245,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /greeting_account\.counter\s*\+=\s*1\s*;/s);
 ```
 
-## 45
+## 43
 
 ### --description--
 
@@ -1311,7 +1274,7 @@ assert.match(
 );
 ```
 
-## 46
+## 44
 
 ### --description--
 
@@ -1335,7 +1298,7 @@ assert.match(
 );
 ```
 
-## 47
+## 45
 
 ### --description--
 
@@ -1352,7 +1315,7 @@ const file = await __helpers.getFile(filePath);
 assert.match(file, /msg!\(/);
 ```
 
-## 48
+## 46
 
 ### --description--
 
@@ -1375,7 +1338,7 @@ const cwd = wds.split('\n').filter(Boolean).pop();
 assert.match(cwd, /src\/program-rust\/?$/);
 ```
 
-## 49
+## 47
 
 ### --description--
 
@@ -1414,7 +1377,7 @@ assert.match(
 );
 ```
 
-## 50
+## 48
 
 ### --description--
 
@@ -1433,7 +1396,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.include(lastCommand, 'solana program show');
 ```
 
-## 51
+## 49
 
 ### --description--
 
@@ -1465,7 +1428,7 @@ assert.match(
 );
 ```
 
-## 52
+## 50
 
 ### --description--
 
@@ -1492,7 +1455,7 @@ const lastCommand = await __helpers.getLastCommand();
 assert.include(lastCommand, 'solana program deploy');
 ```
 
-## 53
+## 51
 
 ### --description--
 
@@ -1535,7 +1498,7 @@ assert.match(
 );
 ```
 
-## 54
+## 52
 
 ### --description--
 
@@ -1582,7 +1545,7 @@ assert.match(
 );
 ```
 
-## 55
+## 53
 
 ### --description--
 
@@ -1620,7 +1583,7 @@ try {
 }
 ```
 
-## 56
+## 54
 
 ### --description--
 
@@ -1661,7 +1624,7 @@ assert.match(
 );
 ```
 
-## 57
+## 55
 
 ### --description--
 
@@ -1695,7 +1658,7 @@ try {
 }
 ```
 
-## 58
+## 56
 
 ### --description--
 

--- a/freecodecamp.conf.json
+++ b/freecodecamp.conf.json
@@ -1,6 +1,6 @@
 {
   "path": ".",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "scripts": {
     "develop-course": "NODE_ENV=development node ./node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/server.js",
     "run-course": "NODE_ENV=production node ./node_modules/@freecodecamp/freecodecamp-os/.freeCodeCamp/tooling/server.js",

--- a/learn-how-to-set-up-solana-by-building-a-hello-world-smart-contract/src/program-rust/Cargo.toml
+++ b/learn-how-to-set-up-solana-by-building-a-hello-world-smart-contract/src/program-rust/Cargo.toml
@@ -16,12 +16,12 @@ edition = "2021"
 no-entrypoint = []
 
 [dependencies]
-borsh = "0.10.3"
-borsh-derive = "0.10.3"
-solana-program = "1.17.3"
+borsh = "=1.2.1"
+borsh-derive = "=1.2.1"
+solana-program = "=1.17.18"
 
 [dev-dependencies]
-solana-sdk = "1.17.3"
+solana-sdk = "=1.17.18"
 
 [lib]
 name = "helloworld"

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,13 +8,13 @@
       "name": "solana-curriculum",
       "version": "1.0.0",
       "dependencies": {
-        "@babel/parser": "7.23.0",
+        "@babel/parser": "7.24.5",
         "@freecodecamp/freecodecamp-os": "1.10.0",
-        "@metaplex-foundation/js": "0.19.3",
-        "@solana/spl-token": "0.3.7",
-        "@solana/web3.js": "1.87.7",
+        "@metaplex-foundation/js": "0.20.1",
+        "@solana/spl-token": "0.4.6",
+        "@solana/web3.js": "1.91.8",
         "babeliser": "0.6.0",
-        "borsh": "0.7.0"
+        "borsh": "2.0.0"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -438,9 +438,9 @@
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.23.0",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.0.tgz",
-      "integrity": "sha512-vvPKKdMemU85V9WE/l5wZEmImpCtLqbnTvqDS2U1fJ96KrxoW7KrXhNsNCblQlg8Ck4b85yxdTyelsMUgFUXiw==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.24.5.tgz",
+      "integrity": "sha512-EOv5IK8arwh3LI47dz1b0tKUb/1uhHAnHJOrjgtQMIpu1uXd9mlFrJg9IUgGUgZ41Ch0K8REPTYpO7B76b4vJg==",
       "bin": {
         "parser": "bin/babel-parser.js"
       },
@@ -1710,9 +1710,9 @@
       "integrity": "sha512-x/rqGMdzj+fWZvCOYForTghzbtqPDZ5gPwaoNGHdgDfF2QA/XZbCBp4Moo5scrkAMPhB7z26XM/AaHuIJdgauA=="
     },
     "node_modules/@babel/runtime": {
-      "version": "7.24.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.4.tgz",
-      "integrity": "sha512-dkxf7+hn8mFBwKjs9bvBlArzLVxVbS8usaPUDd5p2a9JCL9tB8OaOVN1isD4+Xyk4ns89/xeOmbQvgdK7IIVdA==",
+      "version": "7.24.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.24.5.tgz",
+      "integrity": "sha512-Nms86NXrsaeU9vbBJKni6gXiEXZ4CVpYVzEjDH9Sb8vmZ3UljyA1GSOJl/6LGPO8EHLuSF9H+IxNXHPX8QHJ4g==",
       "dependencies": {
         "regenerator-runtime": "^0.14.0"
       },
@@ -1766,41 +1766,36 @@
         "node": ">=6.9.0"
       }
     },
-    "node_modules/@bundlr-network/client": {
-      "version": "0.8.9",
-      "resolved": "https://registry.npmjs.org/@bundlr-network/client/-/client-0.8.9.tgz",
-      "integrity": "sha512-SJ7BAt/KhONeFQ0+nbqrw2DUWrsev6y6cmlXt+3x7fPCkw7OJwudtxV/h2nBteZd65NXjqw8yzkmLiLfZ7CCRA==",
-      "dependencies": {
-        "@solana/wallet-adapter-base": "^0.9.2",
-        "@solana/web3.js": "^1.36.0",
-        "@supercharge/promise-pool": "^2.1.0",
-        "algosdk": "^1.13.1",
-        "arbundles": "^0.6.21",
-        "arweave": "^1.11.4",
-        "async-retry": "^1.3.3",
-        "axios": "^0.25.0",
-        "base64url": "^3.0.1",
-        "bignumber.js": "^9.0.1",
-        "bs58": "^4.0.1",
-        "commander": "^8.2.0",
-        "csv": "^6.0.5",
-        "ethers": "^5.5.1",
-        "inquirer": "^8.2.0",
-        "js-sha256": "^0.9.0",
-        "mime-types": "^2.1.34",
-        "near-api-js": "^0.44.2",
-        "near-seed-phrase": "^0.2.0"
-      },
-      "bin": {
-        "bundlr": "build/node/cli.js"
-      }
-    },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
       "integrity": "sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/@ethereumjs/rlp": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/rlp/-/rlp-4.0.1.tgz",
+      "integrity": "sha512-tqsQiBQDQdmPWE1xkkBq4rlSW5QZpLOUJ5RJh2/9fug+q9tnUhuZoVLk7s0scUIKTOzEtR72DFBXI4WiZcMpvw==",
+      "bin": {
+        "rlp": "bin/rlp"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@ethereumjs/util": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/@ethereumjs/util/-/util-8.1.0.tgz",
+      "integrity": "sha512-zQ0IqbdX8FZ9aw11vP+dZkKDkS+kgIvQPHnSAXzP9pLu+Rfu3D3XEeLbicvoXJTYnhZiPmsZUxgdzXwNKxRPbA==",
+      "dependencies": {
+        "@ethereumjs/rlp": "^4.0.1",
+        "ethereum-cryptography": "^2.0.0",
+        "micro-ftch": "^0.3.1"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/@ethersproject/abi": {
@@ -2329,29 +2324,6 @@
         "hash.js": "1.1.7"
       }
     },
-    "node_modules/@ethersproject/solidity": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/solidity/-/solidity-5.7.0.tgz",
-      "integrity": "sha512-HmabMd2Dt/raavyaGukF4XxizWKhKQ24DoLtdNbBmNKUOPqwjsKQSdV9GQtj9CBEea9DlzETlVER1gYeXXBGaA==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/bytes": "^5.7.0",
-        "@ethersproject/keccak256": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0",
-        "@ethersproject/sha2": "^5.7.0",
-        "@ethersproject/strings": "^5.7.0"
-      }
-    },
     "node_modules/@ethersproject/strings": {
       "version": "5.7.0",
       "resolved": "https://registry.npmjs.org/@ethersproject/strings/-/strings-5.7.0.tgz",
@@ -2396,26 +2368,6 @@
         "@ethersproject/properties": "^5.7.0",
         "@ethersproject/rlp": "^5.7.0",
         "@ethersproject/signing-key": "^5.7.0"
-      }
-    },
-    "node_modules/@ethersproject/units": {
-      "version": "5.7.0",
-      "resolved": "https://registry.npmjs.org/@ethersproject/units/-/units-5.7.0.tgz",
-      "integrity": "sha512-pD3xLMy3SJu9kG5xDGI7+xhTEmGXlEqXU4OfNapmfnxLVY4EMSSRp7j1k7eezutBPH7RBN/7QPnwR7hzNlEFeg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
-      "dependencies": {
-        "@ethersproject/bignumber": "^5.7.0",
-        "@ethersproject/constants": "^5.7.0",
-        "@ethersproject/logger": "^5.7.0"
       }
     },
     "node_modules/@ethersproject/wallet": {
@@ -2535,6 +2487,82 @@
         "webpack-dev-server": "4.15.1"
       }
     },
+    "node_modules/@irys/arweave": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@irys/arweave/-/arweave-0.0.2.tgz",
+      "integrity": "sha512-ddE5h4qXbl0xfGlxrtBIwzflaxZUDlDs43TuT0u1OMfyobHul4AA1VEX72Rpzw2bOh4vzoytSqA1jCM7x9YtHg==",
+      "dependencies": {
+        "asn1.js": "^5.4.1",
+        "async-retry": "^1.3.3",
+        "axios": "^1.4.0",
+        "base64-js": "^1.5.1",
+        "bignumber.js": "^9.1.1"
+      }
+    },
+    "node_modules/@irys/query": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/@irys/query/-/query-0.0.1.tgz",
+      "integrity": "sha512-7TCyR+Qn+F54IQQx5PlERgqNwgIQik8hY55iZl/silTHhCo1MI2pvx5BozqPUVCc8/KqRsc2nZd8Bc29XGUjRQ==",
+      "dependencies": {
+        "async-retry": "^1.3.3",
+        "axios": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      }
+    },
+    "node_modules/@irys/sdk": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/@irys/sdk/-/sdk-0.0.2.tgz",
+      "integrity": "sha512-un/e/CmTpgT042gDwCN3AtISrR9OYGMY6V+442pFmSWKrwrsDoIXZ8VlLiYKnrtTm+yquGhjfYy0LDqGWq41pA==",
+      "dependencies": {
+        "@ethersproject/bignumber": "^5.7.0",
+        "@ethersproject/contracts": "^5.7.0",
+        "@ethersproject/providers": "^5.7.2",
+        "@ethersproject/wallet": "^5.7.0",
+        "@irys/query": "^0.0.1",
+        "@near-js/crypto": "^0.0.3",
+        "@near-js/keystores-browser": "^0.0.3",
+        "@near-js/providers": "^0.0.4",
+        "@near-js/transactions": "^0.1.0",
+        "@solana/web3.js": "^1.36.0",
+        "@supercharge/promise-pool": "^3.0.0",
+        "algosdk": "^1.13.1",
+        "aptos": "=1.8.5",
+        "arbundles": "^0.10.0",
+        "async-retry": "^1.3.3",
+        "axios": "^1.4.0",
+        "base64url": "^3.0.1",
+        "bignumber.js": "^9.0.1",
+        "bs58": "5.0.0",
+        "commander": "^8.2.0",
+        "csv": "5.5.3",
+        "inquirer": "^8.2.0",
+        "js-sha256": "^0.9.0",
+        "mime-types": "^2.1.34",
+        "near-seed-phrase": "^0.2.0"
+      },
+      "bin": {
+        "irys": "build/cjs/node/cli.js",
+        "irys-esm": "build/esm/node/cli.js"
+      },
+      "engines": {
+        "node": ">=16.10.0"
+      }
+    },
+    "node_modules/@irys/sdk/node_modules/base-x": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
+      "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
+    },
+    "node_modules/@irys/sdk/node_modules/bs58": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
+      "integrity": "sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==",
+      "dependencies": {
+        "base-x": "^4.0.0"
+      }
+    },
     "node_modules/@jridgewell/gen-mapping": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
@@ -2644,11 +2672,11 @@
       "integrity": "sha512-S9RulC2fFCFOQraz61bij+5YCHhSO9llJegK8c8Y6731fSi6snUSQJdCUqYS8AIgR0TKbQvdvgSyIIdbDFZbBA=="
     },
     "node_modules/@metaplex-foundation/js": {
-      "version": "0.19.3",
-      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.19.3.tgz",
-      "integrity": "sha512-1LglJo7oBaXUAcN/pXH4jLJm7GSchJZJTgv6lNXjqUVMB1iwaXXtRJiaa4jMeq1zOzEgKCIl8YQpxnE3QAK28g==",
+      "version": "0.20.1",
+      "resolved": "https://registry.npmjs.org/@metaplex-foundation/js/-/js-0.20.1.tgz",
+      "integrity": "sha512-aqiLoEiToXdfI5pS+17/GN/dIO2D31gLoVQvEKDQi9XcnOPVhfJerXDmwgKbhp79OGoYxtlvVw+b2suacoUzGQ==",
       "dependencies": {
-        "@bundlr-network/client": "^0.8.8",
+        "@irys/sdk": "^0.0.2",
         "@metaplex-foundation/beet": "0.7.1",
         "@metaplex-foundation/mpl-auction-house": "^2.3.0",
         "@metaplex-foundation/mpl-bubblegum": "^0.6.2",
@@ -2669,9 +2697,26 @@
         "eventemitter3": "^4.0.7",
         "lodash.clonedeep": "^4.5.0",
         "lodash.isequal": "^4.5.0",
-        "merkletreejs": "^0.2.32",
+        "merkletreejs": "^0.3.11",
         "mime": "^3.0.0",
         "node-fetch": "^2.6.7"
+      }
+    },
+    "node_modules/@metaplex-foundation/js/node_modules/@solana/spl-token": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.88.0"
       }
     },
     "node_modules/@metaplex-foundation/js/node_modules/base-x": {
@@ -2719,6 +2764,23 @@
         "ansicolors": "^0.3.2",
         "bn.js": "^5.2.0",
         "debug": "^4.3.3"
+      }
+    },
+    "node_modules/@metaplex-foundation/mpl-auction-house/node_modules/@solana/spl-token": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.88.0"
       }
     },
     "node_modules/@metaplex-foundation/mpl-bubblegum": {
@@ -2852,6 +2914,23 @@
         "debug": "^4.3.4"
       }
     },
+    "node_modules/@metaplex-foundation/mpl-candy-machine/node_modules/@solana/spl-token": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.88.0"
+      }
+    },
     "node_modules/@metaplex-foundation/mpl-candy-machine/node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
@@ -2890,6 +2969,23 @@
         "debug": "^4.3.4"
       }
     },
+    "node_modules/@metaplex-foundation/mpl-token-metadata/node_modules/@solana/spl-token": {
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.11.tgz",
+      "integrity": "sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==",
+      "dependencies": {
+        "@solana/buffer-layout": "^4.0.0",
+        "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-metadata": "^0.1.2",
+        "buffer": "^6.0.3"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.88.0"
+      }
+    },
     "node_modules/@metaplex-foundation/mpl-token-metadata/node_modules/base-x": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
@@ -2903,21 +2999,273 @@
         "base-x": "^4.0.0"
       }
     },
-    "node_modules/@noble/curves": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
-      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+    "node_modules/@near-js/crypto": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/crypto/-/crypto-0.0.3.tgz",
+      "integrity": "sha512-3WC2A1a1cH8Cqrx+0iDjp1ASEEhxN/KHEMENYb0KZH6Hp5bXIY7Akt4quC7JlgJS5ESvEiLa40tS5h0zAhBWGw==",
       "dependencies": {
-        "@noble/hashes": "1.3.2"
+        "@near-js/types": "0.0.3",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "tweetnacl": "^1.0.1"
+      }
+    },
+    "node_modules/@near-js/crypto/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@near-js/keystores": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores/-/keystores-0.0.3.tgz",
+      "integrity": "sha512-mnwLYUt4Td8u1I4QE1FBx2d9hMt3ofiriE93FfOluJ4XiqRqVFakFYiHg6pExg5iEkej/sXugBUFeQ4QizUnew==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.3",
+        "@near-js/types": "0.0.3"
+      }
+    },
+    "node_modules/@near-js/keystores-browser": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores-browser/-/keystores-browser-0.0.3.tgz",
+      "integrity": "sha512-Ve/JQ1SBxdNk3B49lElJ8Y54AoBY+yOStLvdnUIpe2FBOczzwDCkcnPcMDV0NMwVlHpEnOWICWHbRbAkI5Vs+A==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.3",
+        "@near-js/keystores": "0.0.3"
+      }
+    },
+    "node_modules/@near-js/providers": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/providers/-/providers-0.0.4.tgz",
+      "integrity": "sha512-g/2pJTYmsIlTW4mGqeRlqDN9pZeN+1E2/wfoMIf3p++boBVxVlaSebtQgawXAf2lkfhb9RqXz5pHqewXIkTBSw==",
+      "dependencies": {
+        "@near-js/transactions": "0.1.0",
+        "@near-js/types": "0.0.3",
+        "@near-js/utils": "0.0.3",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "http-errors": "^1.7.2"
+      },
+      "optionalDependencies": {
+        "node-fetch": "^2.6.1"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/@near-js/signers": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/signers/-/signers-0.0.3.tgz",
+      "integrity": "sha512-u1R+DDIua5PY1PDFnpVYqdMgQ7c4dyeZsfqMjE7CtgzdqupgTYCXzJjBubqMlAyAx843PoXmLt6CSSKcMm0WUA==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.3",
+        "@near-js/keystores": "0.0.3",
+        "js-sha256": "^0.9.0"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/@near-js/transactions": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@near-js/transactions/-/transactions-0.1.0.tgz",
+      "integrity": "sha512-OrrDFqhX0rtH+6MV3U3iS+zmzcPQI+L4GJi9na4Uf8FgpaVPF0mtSmVrpUrS5CC3LwWCzcYF833xGYbXOV4Kfg==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.3",
+        "@near-js/signers": "0.0.3",
+        "@near-js/types": "0.0.3",
+        "@near-js/utils": "0.0.3",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "js-sha256": "^0.9.0"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/depd": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
+      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@near-js/providers/node_modules/statuses": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
+      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/@near-js/signers": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/signers/-/signers-0.0.4.tgz",
+      "integrity": "sha512-xCglo3U/WIGsz/izPGFMegS5Q3PxOHYB8a1E7RtVhNm5QdqTlQldLCm/BuMg2G/u1l1ZZ0wdvkqRTG9joauf3Q==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.4",
+        "@near-js/keystores": "0.0.4",
+        "js-sha256": "^0.9.0"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/@near-js/crypto": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/crypto/-/crypto-0.0.4.tgz",
+      "integrity": "sha512-2mSIVv6mZway1rQvmkktrXAFoUvy7POjrHNH3LekKZCMCs7qMM/23Hz2+APgxZPqoV2kjarSNOEYJjxO7zQ/rQ==",
+      "dependencies": {
+        "@near-js/types": "0.0.4",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "tweetnacl": "^1.0.1"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/@near-js/keystores": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/keystores/-/keystores-0.0.4.tgz",
+      "integrity": "sha512-+vKafmDpQGrz5py1liot2hYSjPGXwihveeN+BL11aJlLqZnWBgYJUWCXG+uyGjGXZORuy2hzkKK6Hi+lbKOfVA==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.4",
+        "@near-js/types": "0.0.4"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/@near-js/types": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/types/-/types-0.0.4.tgz",
+      "integrity": "sha512-8TTMbLMnmyG06R5YKWuS/qFG1tOA3/9lX4NgBqQPsvaWmDsa+D+QwOkrEHDegped0ZHQwcjAXjKML1S1TyGYKg==",
+      "dependencies": {
+        "bn.js": "5.2.1"
+      }
+    },
+    "node_modules/@near-js/signers/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@near-js/transactions": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@near-js/transactions/-/transactions-0.1.1.tgz",
+      "integrity": "sha512-Fk83oLLFK7nz4thawpdv9bGyMVQ2i48iUtZEVYhuuuqevl17tSXMlhle9Me1ZbNyguJG/cWPdNybe1UMKpyGxA==",
+      "dependencies": {
+        "@near-js/crypto": "0.0.4",
+        "@near-js/signers": "0.0.4",
+        "@near-js/types": "0.0.4",
+        "@near-js/utils": "0.0.4",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "js-sha256": "^0.9.0"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/@near-js/crypto": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/crypto/-/crypto-0.0.4.tgz",
+      "integrity": "sha512-2mSIVv6mZway1rQvmkktrXAFoUvy7POjrHNH3LekKZCMCs7qMM/23Hz2+APgxZPqoV2kjarSNOEYJjxO7zQ/rQ==",
+      "dependencies": {
+        "@near-js/types": "0.0.4",
+        "bn.js": "5.2.1",
+        "borsh": "^0.7.0",
+        "tweetnacl": "^1.0.1"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/@near-js/types": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/types/-/types-0.0.4.tgz",
+      "integrity": "sha512-8TTMbLMnmyG06R5YKWuS/qFG1tOA3/9lX4NgBqQPsvaWmDsa+D+QwOkrEHDegped0ZHQwcjAXjKML1S1TyGYKg==",
+      "dependencies": {
+        "bn.js": "5.2.1"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/@near-js/utils": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@near-js/utils/-/utils-0.0.4.tgz",
+      "integrity": "sha512-mPUEPJbTCMicGitjEGvQqOe8AS7O4KkRCxqd0xuE/X6gXF1jz1pYMZn4lNUeUz2C84YnVSGLAM0o9zcN6Y4hiA==",
+      "dependencies": {
+        "@near-js/types": "0.0.4",
+        "bn.js": "5.2.1",
+        "depd": "^2.0.0",
+        "mustache": "^4.0.0"
+      }
+    },
+    "node_modules/@near-js/transactions/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@near-js/types": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/types/-/types-0.0.3.tgz",
+      "integrity": "sha512-gC3iGUT+r2JjVsE31YharT+voat79ToMUMLCGozHjp/R/UW1M2z4hdpqTUoeWUBGBJuVc810gNTneHGx0jvzwQ==",
+      "dependencies": {
+        "bn.js": "5.2.1"
+      }
+    },
+    "node_modules/@near-js/utils": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@near-js/utils/-/utils-0.0.3.tgz",
+      "integrity": "sha512-J72n/EL0VfLRRb4xNUF4rmVrdzMkcmkwJOhBZSTWz3PAZ8LqNeU9ZConPfMvEr6lwdaD33ZuVv70DN6IIjPr1A==",
+      "dependencies": {
+        "@near-js/types": "0.0.3",
+        "bn.js": "5.2.1",
+        "depd": "^2.0.0",
+        "mustache": "^4.0.0"
+      }
+    },
+    "node_modules/@noble/curves": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.4.0.tgz",
+      "integrity": "sha512-p+4cb332SFCrReJkCYe8Xzm0OWi4Jji5jVdIZRL/PmacmDkFNw6MrrV+gGpiPxLHbV+zKFRywUWbaseT+tZRXg==",
+      "dependencies": {
+        "@noble/hashes": "1.4.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@noble/ed25519": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.1.tgz",
-      "integrity": "sha512-Rk4SkJFaXZiznFyC/t77Q0NKS4FL7TLJJsVG2V2oiEq3kJVeTdxysEe/yRWSpnWMe808XRDJ+VFh5pt/FN5plw==",
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@noble/ed25519/-/ed25519-1.7.3.tgz",
+      "integrity": "sha512-iR8GBkDt0Q3GyaVcIu7mSsVIqnFbkbRzGLWlvhwunacoLwt4J3swfKhfaM6rN6WY+TBGoYT1GtT1mIh2/jGbRQ==",
       "funding": [
         {
           "type": "individual",
@@ -2926,9 +3274,9 @@
       ]
     },
     "node_modules/@noble/hashes": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
-      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.3.tgz",
+      "integrity": "sha512-V7/fPHgl+jsVPXqqeOzT8egNj2iBIVt+ECeMMG8TdcnTikP3oaBtUVqpT/gYCR68aEBJSF+XbYUxStjbFMqIIA==",
       "engines": {
         "node": ">= 16"
       },
@@ -2939,20 +3287,80 @@
     "node_modules/@randlabs/communication-bridge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@randlabs/communication-bridge/-/communication-bridge-1.0.1.tgz",
-      "integrity": "sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg=="
+      "integrity": "sha512-CzS0U8IFfXNK7QaJFE4pjbxDGfPjbXBEsEaCn9FN15F+ouSAEUQkva3Gl66hrkBZOGexKFEWMwUHIDKpZ2hfVg==",
+      "optional": true
     },
     "node_modules/@randlabs/myalgo-connect": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/@randlabs/myalgo-connect/-/myalgo-connect-1.4.2.tgz",
       "integrity": "sha512-K9hEyUi7G8tqOp7kWIALJLVbGCByhilcy6123WfcorxWwiE1sbQupPyIU5f3YdQK6wMjBsyTWiLW52ZBMp7sXA==",
+      "optional": true,
       "dependencies": {
         "@randlabs/communication-bridge": "1.0.1"
       }
     },
+    "node_modules/@scure/base": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@scure/base/-/base-1.1.6.tgz",
+      "integrity": "sha512-ok9AWwhcgYuGG3Zfhyqg+zwl+Wn5uE+dwC0NV/2qQkx4dABbb/bx96vWu8NSj+BNjjSjno+JRYRjle1jV08k3g==",
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@scure/bip32/-/bip32-1.3.3.tgz",
+      "integrity": "sha512-LJaN3HwRbfQK0X1xFSi0Q9amqOgzQnnDngIt+ZlsBC3Bm7/nE7K0kwshZHyaru79yIVRv/e1mQAjZyuZG6jOFQ==",
+      "dependencies": {
+        "@noble/curves": "~1.3.0",
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip32/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
+      "dependencies": {
+        "@noble/hashes": "1.3.3"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@scure/bip39": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.1.0.tgz",
+      "integrity": "sha512-pwrPOS16VeTKg98dYXQyIjJEcWfz7/1YJIwxUEPFfQPtc86Ym/1sVgQ2RLoD43AazMk2l/unK4ITySSpW2+82w==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ],
+      "dependencies": {
+        "@noble/hashes": "~1.1.1",
+        "@scure/base": "~1.1.0"
+      }
+    },
+    "node_modules/@scure/bip39/node_modules/@noble/hashes": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.5.tgz",
+      "integrity": "sha512-LTMZiiLc+V4v1Yi16TD6aX2gmtKszNye0pQgbaLqkvhIqP7nVsSaJsWloGQjJfJ8offaoP5GtX3yY5swbcJxxQ==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
     "node_modules/@solana/buffer-layout": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.0.tgz",
-      "integrity": "sha512-lR0EMP2HC3+Mxwd4YcnZb0smnaDw7Bl2IQWZiTevRH5ZZBZn6VRWn3/92E3qdU4SSImJkA6IDHawOHAnx/qUvQ==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@solana/buffer-layout/-/buffer-layout-4.0.1.tgz",
+      "integrity": "sha512-E1ImOIAD1tBZFRdjeM4/pzTiTApC0AOBGwyAMS4fwIodCWArzJ3DWdoh8cKxeFM2fElkxBh2Aqts1BPC373rHA==",
       "dependencies": {
         "buffer": "~6.0.3"
       },
@@ -2972,6 +3380,98 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/@solana/codecs": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs/-/codecs-2.0.0-preview.2.tgz",
+      "integrity": "sha512-4HHzCD5+pOSmSB71X6w9ptweV48Zj1Vqhe732+pcAQ2cMNnN0gMPMdDq7j3YwaZDZ7yrILVV/3+HTnfT77t2yA==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-data-structures": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/codecs-strings": "2.0.0-preview.2",
+        "@solana/options": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-core": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-core/-/codecs-core-2.0.0-preview.2.tgz",
+      "integrity": "sha512-gLhCJXieSCrAU7acUJjbXl+IbGnqovvxQLlimztPoGgfLQ1wFYu+XJswrEVQqknZYK1pgxpxH3rZ+OKFs0ndQg==",
+      "dependencies": {
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-data-structures": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-data-structures/-/codecs-data-structures-2.0.0-preview.2.tgz",
+      "integrity": "sha512-Xf5vIfromOZo94Q8HbR04TbgTwzigqrKII0GjYr21K7rb3nba4hUW2ir8kguY7HWFBcjHGlU5x3MevKBOLp3Zg==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-numbers": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-numbers/-/codecs-numbers-2.0.0-preview.2.tgz",
+      "integrity": "sha512-aLZnDTf43z4qOnpTcDsUVy1Ci9im1Md8thWipSWbE+WM9ojZAx528oAql+Cv8M8N+6ALKwgVRhPZkto6E59ARw==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      }
+    },
+    "node_modules/@solana/codecs-strings": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/codecs-strings/-/codecs-strings-2.0.0-preview.2.tgz",
+      "integrity": "sha512-EgBwY+lIaHHgMJIqVOGHfIfpdmmUDNoNO/GAUGeFPf+q0dF+DtwhJPEMShhzh64X2MeCZcmSO6Kinx0Bvmmz2g==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2",
+        "@solana/errors": "2.0.0-preview.2"
+      },
+      "peerDependencies": {
+        "fastestsmallesttextencoderdecoder": "^1.0.22"
+      }
+    },
+    "node_modules/@solana/errors": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/errors/-/errors-2.0.0-preview.2.tgz",
+      "integrity": "sha512-H2DZ1l3iYF5Rp5pPbJpmmtCauWeQXRJapkDg8epQ8BJ7cA2Ut/QEtC3CMmw/iMTcuS6uemFNLcWvlOfoQhvQuA==",
+      "dependencies": {
+        "chalk": "^5.3.0",
+        "commander": "^12.0.0"
+      },
+      "bin": {
+        "errors": "bin/cli.js"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/chalk": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
+      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
+      "engines": {
+        "node": "^12.17.0 || ^14.13 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@solana/errors/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@solana/options": {
+      "version": "2.0.0-preview.2",
+      "resolved": "https://registry.npmjs.org/@solana/options/-/options-2.0.0-preview.2.tgz",
+      "integrity": "sha512-FAHqEeH0cVsUOTzjl5OfUBw2cyT8d5Oekx4xcn5hn+NyPAfQJgM3CEThzgRD6Q/4mM5pVUnND3oK/Mt1RzSE/w==",
+      "dependencies": {
+        "@solana/codecs-core": "2.0.0-preview.2",
+        "@solana/codecs-numbers": "2.0.0-preview.2"
       }
     },
     "node_modules/@solana/spl-account-compression": {
@@ -3009,6 +3509,32 @@
       "resolved": "https://registry.npmjs.org/base-x/-/base-x-4.0.0.tgz",
       "integrity": "sha512-FuwxlW4H5kh37X/oW59pwTzzTKRzfrrQwhmyspRM7swOEZcHtDZSCt45U6oKgtuFE+WYPblePMVIPR4RZrh/hw=="
     },
+    "node_modules/@solana/spl-account-compression/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
+      }
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/borsh/node_modules/base-x": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.9.tgz",
+      "integrity": "sha512-H7JU6iBHTal1gp56aKoaa//YUxEaAOUiydvrV/pILqIHXTtqxSkATOnDA2u+jZ/61sD+L/412+7kzXRtWukhpQ==",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/@solana/spl-account-compression/node_modules/borsh/node_modules/bs58": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/bs58/-/bs58-4.0.1.tgz",
+      "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
+      "dependencies": {
+        "base-x": "^3.0.2"
+      }
+    },
     "node_modules/@solana/spl-account-compression/node_modules/bs58": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/bs58/-/bs58-5.0.0.tgz",
@@ -3018,60 +3544,74 @@
       }
     },
     "node_modules/@solana/spl-token": {
-      "version": "0.3.7",
-      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.3.7.tgz",
-      "integrity": "sha512-bKGxWTtIw6VDdCBngjtsGlKGLSmiu/8ghSt/IOYJV24BsymRbgq7r12GToeetpxmPaZYLddKwAz7+EwprLfkfg==",
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token/-/spl-token-0.4.6.tgz",
+      "integrity": "sha512-1nCnUqfHVtdguFciVWaY/RKcQz1IF4b31jnKgAmjU9QVN1q7dRUkTEWJZgTYIEtsULjVnC9jRqlhgGN39WbKKA==",
       "dependencies": {
         "@solana/buffer-layout": "^4.0.0",
         "@solana/buffer-layout-utils": "^0.2.0",
+        "@solana/spl-token-group": "^0.0.4",
+        "@solana/spl-token-metadata": "^0.1.4",
         "buffer": "^6.0.3"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.47.4"
+        "@solana/web3.js": "^1.91.6"
       }
     },
-    "node_modules/@solana/wallet-adapter-base": {
-      "version": "0.9.22",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-adapter-base/-/wallet-adapter-base-0.9.22.tgz",
-      "integrity": "sha512-xbLEZPGSJFvgTeldG9D55evhl7QK/3e/F7vhvcA97mEt1eieTgeKMnGlmmjs3yivI3/gtZNZeSk1XZLnhKcQvw==",
+    "node_modules/@solana/spl-token-group": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-group/-/spl-token-group-0.0.4.tgz",
+      "integrity": "sha512-7+80nrEMdUKlK37V6kOe024+T7J4nNss0F8LQ9OOPYdWCCfJmsGUzVx2W3oeizZR4IHM6N4yC9v1Xqwc3BTPWw==",
       "dependencies": {
-        "@solana/wallet-standard-features": "^1.0.1",
-        "@wallet-standard/base": "^1.0.1",
-        "@wallet-standard/features": "^1.0.3",
-        "eventemitter3": "^4.0.7"
+        "@solana/codecs": "2.0.0-preview.2",
+        "@solana/spl-type-length-value": "0.1.0"
       },
       "engines": {
         "node": ">=16"
       },
       "peerDependencies": {
-        "@solana/web3.js": "^1.58.0"
+        "@solana/web3.js": "^1.91.6"
       }
     },
-    "node_modules/@solana/wallet-standard-features": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@solana/wallet-standard-features/-/wallet-standard-features-1.0.1.tgz",
-      "integrity": "sha512-SUfx7KtBJ55XIj0qAhhVcC1I6MklAXqWFEz9hDHW+6YcJIyvfix/EilBhaBik1FJ2JT0zukpOfFv8zpuAbFRbw==",
+    "node_modules/@solana/spl-token-metadata": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@solana/spl-token-metadata/-/spl-token-metadata-0.1.4.tgz",
+      "integrity": "sha512-N3gZ8DlW6NWDV28+vCCDJoTqaCZiF/jDUnk3o8GRkAFzHObiR60Bs1gXHBa8zCPdvOwiG6Z3dg5pg7+RW6XNsQ==",
       "dependencies": {
-        "@wallet-standard/base": "^1.0.1",
-        "@wallet-standard/features": "^1.0.3"
+        "@solana/codecs": "2.0.0-preview.2",
+        "@solana/spl-type-length-value": "0.1.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "peerDependencies": {
+        "@solana/web3.js": "^1.91.6"
+      }
+    },
+    "node_modules/@solana/spl-type-length-value": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/@solana/spl-type-length-value/-/spl-type-length-value-0.1.0.tgz",
+      "integrity": "sha512-JBMGB0oR4lPttOZ5XiUGyvylwLQjt1CPJa6qQ5oM+MBCndfjz2TKKkw0eATlLLcYmq1jBVsNlJ2cD6ns2GR7lA==",
+      "dependencies": {
+        "buffer": "^6.0.3"
       },
       "engines": {
         "node": ">=16"
       }
     },
     "node_modules/@solana/web3.js": {
-      "version": "1.87.7",
-      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.87.7.tgz",
-      "integrity": "sha512-GxebSfR/Z69SgiJJv0hQgh7gt/ojZIrPVDSF79XnruyCTKj7XMGtJKu9tRblHbhICoVHBPZftfTlgMT6lCpEwg==",
+      "version": "1.91.8",
+      "resolved": "https://registry.npmjs.org/@solana/web3.js/-/web3.js-1.91.8.tgz",
+      "integrity": "sha512-USa6OS1jbh8zOapRJ/CBZImZ8Xb7AJjROZl5adql9TpOoBN9BUzyyouS5oPuZHft7S7eB8uJPuXWYjMi6BHgOw==",
       "dependencies": {
-        "@babel/runtime": "^7.23.2",
-        "@noble/curves": "^1.2.0",
-        "@noble/hashes": "^1.3.1",
-        "@solana/buffer-layout": "^4.0.0",
-        "agentkeepalive": "^4.3.0",
+        "@babel/runtime": "^7.24.5",
+        "@noble/curves": "^1.4.0",
+        "@noble/hashes": "^1.4.0",
+        "@solana/buffer-layout": "^4.0.1",
+        "agentkeepalive": "^4.5.0",
         "bigint-buffer": "^1.1.5",
         "bn.js": "^5.2.1",
         "borsh": "^0.7.0",
@@ -3079,44 +3619,38 @@
         "buffer": "6.0.3",
         "fast-stable-stringify": "^1.0.0",
         "jayson": "^4.1.0",
-        "node-fetch": "^2.6.12",
-        "rpc-websockets": "^7.5.1",
+        "node-fetch": "^2.7.0",
+        "rpc-websockets": "^7.11.0",
         "superstruct": "^0.14.2"
       }
     },
-    "node_modules/@solana/web3.js/node_modules/node-fetch": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
-      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
+    "node_modules/@solana/web3.js/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
       "engines": {
-        "node": "4.x || >=6.0.0"
+        "node": ">= 16"
       },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@solana/web3.js/node_modules/borsh": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
+      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
+      "dependencies": {
+        "bn.js": "^5.2.0",
+        "bs58": "^4.0.0",
+        "text-encoding-utf-8": "^1.0.2"
       }
     },
     "node_modules/@supercharge/promise-pool": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-2.4.0.tgz",
-      "integrity": "sha512-O9CMipBlq5OObdt1uKJGIzm9cdjpPWfj+a+Zw9EgWKxaMNHKC7EU7X9taj3H0EGQNLOSq2jAcOa3EzxlfHsD6w==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@supercharge/promise-pool/-/promise-pool-3.2.0.tgz",
+      "integrity": "sha512-pj0cAALblTZBPtMltWOlZTQSLT07jIaFNeM8TWoJD1cQMgDB9mcMlVMoetiB35OzNJpqQ2b+QEtwiR9f20mADg==",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/@types/bn.js": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/@types/bn.js/-/bn.js-5.1.1.tgz",
-      "integrity": "sha512-qNrYbZqMx0uJAfKnKclPh+dTwK33KfLHYqtyODwd5HnXOjnkhc4qgn3BrK6RWyGZm5+sIFE7Q7Vz6QQtJB7w7g==",
-      "dependencies": {
-        "@types/node": "*"
       }
     },
     "node_modules/@types/body-parser": {
@@ -3234,14 +3768,6 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-18.17.3.tgz",
       "integrity": "sha512-2x8HWtFk0S99zqVQABU9wTpr8wPoaDHZUcAkoTKH+nL7kPv3WUI9cRi/Kk5Mz4xdqXSqTkKP7IWNoQQYCnDsTA=="
     },
-    "node_modules/@types/pbkdf2": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/@types/pbkdf2/-/pbkdf2-3.1.0.tgz",
-      "integrity": "sha512-Cf63Rv7jCQ0LaL8tNXmEyqTHuIJxRdlS5vMh1mj5voN4+QFhVZnlZruezqpWYDiJ8UTzhP0VmeLXCmBk66YrMQ==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/prismjs": {
       "version": "1.26.0",
       "resolved": "https://registry.npmjs.org/@types/prismjs/-/prismjs-1.26.0.tgz",
@@ -3290,14 +3816,6 @@
       "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.3.tgz",
       "integrity": "sha512-5cJ8CB4yAx7BH1oMvdU0Jh9lrEXyPkar6F9G/ERswkCuvP4KQZfZkSjcMbAICCpQTN4OuZn8tz0HiKv9TGZgrQ=="
     },
-    "node_modules/@types/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/@types/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-Da66lEIFeIz9ltsdMZcpQvmrmmoqrfju8pm1BH8WbYjZSwUgCwXLb9C+9XYogwBITnbsSaMdVPb2ekf7TV+03w==",
-      "dependencies": {
-        "@types/node": "*"
-      }
-    },
     "node_modules/@types/send": {
       "version": "0.17.1",
       "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.1.tgz",
@@ -3338,25 +3856,6 @@
       "integrity": "sha512-JQbbmxZTZehdc2iszGKs5oC3NFnjeay7mtAWrdt7qNtAVK0g19muApzAy4bm9byz79xa2ZnO/BOBC2R8RC5Lww==",
       "dependencies": {
         "@types/node": "*"
-      }
-    },
-    "node_modules/@wallet-standard/base": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/base/-/base-1.0.1.tgz",
-      "integrity": "sha512-1To3ekMfzhYxe0Yhkpri+Fedq0SYcfrOfJi3vbLjMwF2qiKPjTGLwZkf2C9ftdQmxES+hmxhBzTwF4KgcOwf8w==",
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@wallet-standard/features": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/@wallet-standard/features/-/features-1.0.3.tgz",
-      "integrity": "sha512-m8475I6W5LTatTZuUz5JJNK42wFRgkJTB0I9tkruMwfqBF2UN2eomkYNVf9RbrsROelCRzSFmugqjKZBFaubsA==",
-      "dependencies": {
-        "@wallet-standard/base": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=16"
       }
     },
     "node_modules/@webassemblyjs/ast": {
@@ -3593,12 +4092,10 @@
       "integrity": "sha512-H7wUZRn8WpTq9jocdxQ2c8x2sKo9ZVmzfRE13GiNJXfp7NcKYEdvl3vspKjXox6RIG2VtaRe4JFvxG4rqp2Zuw=="
     },
     "node_modules/agentkeepalive": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.4.0.tgz",
-      "integrity": "sha512-MysLRwkhsJTZKs+fsZIsTgBlr3IjQroonVJWMSqC9k3LS6f6ZifePl9fCqOtvc8p0CeYDSZVFvytdkwhOGaSZA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.5.0.tgz",
+      "integrity": "sha512-5GG/5IbQQpC9FpkRGsSvZI5QYeSCzlJHdpBQntCsuTOxhKD8lqKhrleg2Yi7yvMIf82Ycmmqln9U8V9qwEiJew==",
       "dependencies": {
-        "debug": "^4.1.0",
-        "depd": "^2.0.0",
         "humanize-ms": "^1.2.1"
       },
       "engines": {
@@ -3753,41 +4250,73 @@
         "node": ">= 8"
       }
     },
-    "node_modules/arbundles": {
-      "version": "0.6.22",
-      "resolved": "https://registry.npmjs.org/arbundles/-/arbundles-0.6.22.tgz",
-      "integrity": "sha512-QlSavBHk59mNqgQ6ScxlqaBJlDbSmSrK/uTcF3HojLAZ/4aufTkVTBjl1hSfZ/ZN45oIPgJC05R8SmVARF+8VA==",
+    "node_modules/aptos": {
+      "version": "1.8.5",
+      "resolved": "https://registry.npmjs.org/aptos/-/aptos-1.8.5.tgz",
+      "integrity": "sha512-iQxliWesNHjGQ5YYXCyss9eg4+bDGQWqAZa73vprqGQ9tungK0cRjUI2fmnp63Ed6UG6rurHrL+b0ckbZAOZZQ==",
       "dependencies": {
-        "@noble/ed25519": "^1.6.1",
-        "@randlabs/myalgo-connect": "^1.1.2",
-        "@solana/wallet-adapter-base": "^0.9.2",
-        "algosdk": "^1.13.1",
-        "arweave": "^1.11.4",
-        "arweave-stream-tx": "^1.1.0",
-        "avsc": "https://github.com/Bundlr-Network/avsc#csp-fixes",
-        "axios": "^0.21.3",
-        "base64url": "^3.0.1",
-        "bs58": "^4.0.1",
-        "ethers": "^5.5.1",
-        "keccak": "^3.0.2",
-        "multistream": "^4.1.0",
-        "process": "^0.11.10",
-        "secp256k1": "^4.0.2",
-        "tmp-promise": "^3.0.2"
+        "@noble/hashes": "1.1.3",
+        "@scure/bip39": "1.1.0",
+        "axios": "0.27.2",
+        "form-data": "4.0.0",
+        "tweetnacl": "1.0.3"
+      },
+      "engines": {
+        "node": ">=11.0.0"
       }
     },
-    "node_modules/arbundles/node_modules/axios": {
-      "version": "0.21.4",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-      "integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+    "node_modules/aptos/node_modules/@noble/hashes": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.3.tgz",
+      "integrity": "sha512-CE0FCR57H2acVI5UOzIGSSIYxZ6v/HOhDR0Ro9VLyhnzLwx0o8W1mmgaqlEUx4049qJDlIBRztv5k+MM8vbO3A==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://paulmillr.com/funding/"
+        }
+      ]
+    },
+    "node_modules/aptos/node_modules/axios": {
+      "version": "0.27.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.27.2.tgz",
+      "integrity": "sha512-t+yRIyySRTp/wua5xEr+z1q60QmLq8ABsS5O9Me1AsE5dfKqgnCFzwiCZZ/cGNd1lq4/7akDWMxdhVlucjmnOQ==",
       "dependencies": {
-        "follow-redirects": "^1.14.0"
+        "follow-redirects": "^1.14.9",
+        "form-data": "^4.0.0"
+      }
+    },
+    "node_modules/arbundles": {
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/arbundles/-/arbundles-0.10.1.tgz",
+      "integrity": "sha512-QYFepxessLCirvRkQK9iQmjxjHz+s50lMNGRwZwpyPWLohuf6ISyj1gkFXJHlMT+rNSrsHxb532glHnKbjwu3A==",
+      "dependencies": {
+        "@ethersproject/bytes": "^5.7.0",
+        "@ethersproject/hash": "^5.7.0",
+        "@ethersproject/providers": "^5.7.2",
+        "@ethersproject/signing-key": "^5.7.0",
+        "@ethersproject/transactions": "^5.7.0",
+        "@ethersproject/wallet": "^5.7.0",
+        "@irys/arweave": "^0.0.2",
+        "@noble/ed25519": "^1.6.1",
+        "base64url": "^3.0.1",
+        "bs58": "^4.0.1",
+        "keccak": "^3.0.2",
+        "secp256k1": "^5.0.0"
+      },
+      "optionalDependencies": {
+        "@randlabs/myalgo-connect": "^1.1.2",
+        "algosdk": "^1.13.1",
+        "arweave-stream-tx": "^1.1.0",
+        "multistream": "^4.1.0",
+        "tmp-promise": "^3.0.2"
       }
     },
     "node_modules/arconnect": {
       "version": "0.4.2",
       "resolved": "https://registry.npmjs.org/arconnect/-/arconnect-0.4.2.tgz",
       "integrity": "sha512-Jkpd4QL3TVqnd3U683gzXmZUVqBUy17DdJDuL/3D9rkysLgX6ymJ2e+sR+xyZF5Rh42CBqDXWNMmCjBXeP7Gbw==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "arweave": "^1.10.13"
       }
@@ -3798,9 +4327,11 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg=="
     },
     "node_modules/arweave": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/arweave/-/arweave-1.13.1.tgz",
-      "integrity": "sha512-B6+N/5Ngvm0w1XTcboRbHGhyJkLmneqz8F5FaoVtd8KHVrzJ8cGq/dBAToP+QL4QJXlRudjLMxX7Mm9tzJt2xQ==",
+      "version": "1.15.1",
+      "resolved": "https://registry.npmjs.org/arweave/-/arweave-1.15.1.tgz",
+      "integrity": "sha512-rT7FOwqdudd5npqp4xOYdDT2035LtpcqePjwirh4wjRiEtVsz1FZkRiM2Yj+fOAwYzOm/hNG0GDOipDSaiEGGQ==",
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "arconnect": "^0.4.2",
         "asn1.js": "^5.4.1",
@@ -3808,13 +4339,14 @@
         "bignumber.js": "^9.0.2"
       },
       "engines": {
-        "node": ">=16.15.0"
+        "node": ">=18"
       }
     },
     "node_modules/arweave-stream-tx": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/arweave-stream-tx/-/arweave-stream-tx-1.2.2.tgz",
       "integrity": "sha512-bNt9rj0hbAEzoUZEF2s6WJbIz8nasZlZpxIw03Xm8fzb9gRiiZlZGW3lxQLjfc9Z0VRUWDzwtqoYeEoB/JDToQ==",
+      "optional": true,
       "dependencies": {
         "exponential-backoff": "^3.1.0"
       },
@@ -3854,20 +4386,19 @@
         "retry": "0.13.1"
       }
     },
-    "node_modules/avsc": {
-      "version": "5.4.7",
-      "resolved": "git+ssh://git@github.com/Bundlr-Network/avsc.git#a730cc8018b79e114b6a3381bbb57760a24c6cef",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.11"
-      }
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.7.2.tgz",
+      "integrity": "sha512-2A8QhOMrbomlDuiLeK9XibIBzuHeRcqqNOHp0Cyp5EoJ1IFDh+XZH3A6BkXtv0K4gFGCI0Y4BM7B1wOEi0Rmgw==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.6",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
     "node_modules/babel-loader": {
@@ -4101,11 +4632,6 @@
         "ieee754": "^1.1.13"
       }
     },
-    "node_modules/blakejs": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/blakejs/-/blakejs-1.2.1.tgz",
-      "integrity": "sha512-QXUSXI3QVc/gJME0dBpXrag1kbzOqCjCX8/b54ntNyW6sjtoqxqRk3LTmXzaJoh71zMsDCjM+47jS7XiwN/+fQ=="
-    },
     "node_modules/bn.js": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.1.tgz",
@@ -4169,14 +4695,9 @@
       "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww=="
     },
     "node_modules/borsh": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.7.0.tgz",
-      "integrity": "sha512-CLCsZGIBCFnPtkNnieW/a8wmreDmfUtjU2m9yHrzPXIlNbqVs0AQrSatSG6vdNYUqdc83tkQi2eHfF98ubzQLA==",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/borsh/-/borsh-2.0.0.tgz",
+      "integrity": "sha512-kc9+BgR3zz9+cjbwM8ODoUB4fs3X3I5A/HtX7LZKxCLaMrEeDFoBpnhZY//DTS1VZBSs6S5v46RZRbZjRFspEg=="
     },
     "node_modules/brace-expansion": {
       "version": "1.1.11",
@@ -4202,19 +4723,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/brorand/-/brorand-1.1.0.tgz",
       "integrity": "sha512-cKV8tMCEpQs4hK/ik71d6LrPOnpkpGBR0wzxqr68g2m/LB2GxVYQroAjMJZRVM1Y4BCjCKc3vAamxSzOY2RP+w=="
-    },
-    "node_modules/browserify-aes": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
-      "integrity": "sha512-+7CHXqGuspUn/Sl5aO7Ea0xWGAtETPXNSAjHo48JfLdPWcMng33Xe4znFvQweqc/uzk5zSOI3H52CYnjCfb5hA==",
-      "dependencies": {
-        "buffer-xor": "^1.0.3",
-        "cipher-base": "^1.0.0",
-        "create-hash": "^1.1.0",
-        "evp_bytestokey": "^1.0.3",
-        "inherits": "^2.0.1",
-        "safe-buffer": "^5.0.1"
-      }
     },
     "node_modules/browserslist": {
       "version": "4.21.10",
@@ -4253,16 +4761,6 @@
       "integrity": "sha512-Ok3Wdf5vOIlBrgCvTq96gBkJw+JUEzdBgyaza5HLtPm7yTHkjRy8+JzNyHF7BHa0bNWOQIp3m5YF0nnFcOIKLw==",
       "dependencies": {
         "base-x": "^3.0.2"
-      }
-    },
-    "node_modules/bs58check": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/bs58check/-/bs58check-2.1.2.tgz",
-      "integrity": "sha512-0TS1jicxdU09dwJMNZtVAfzPi6Q6QeN0pM1Fkzrjn+XYHvzMKPU3pHVpva+769iNVSfIYWf7LJ6WR+BuuMf8cA==",
-      "dependencies": {
-        "bs58": "^4.0.0",
-        "create-hash": "^1.1.0",
-        "safe-buffer": "^5.1.2"
       }
     },
     "node_modules/buffer": {
@@ -4305,11 +4803,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/buffer-reverse/-/buffer-reverse-1.0.1.tgz",
       "integrity": "sha512-M87YIUBsZ6N924W57vDwT/aOu8hw7ZgdByz6ijksLjmHJELBASmYTTlNHRgjE+pTsT9oJXGaDSgqqwfdHotDUg=="
-    },
-    "node_modules/buffer-xor": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
-      "integrity": "sha512-571s0T7nZWK6vB67HI5dyUF7wXiNcfaPPPTl6zYCNApANjIvYJTg7hlud/+cJpdAhS7dVzqMLmfhfHR3rAcOjQ=="
     },
     "node_modules/bufferutil": {
       "version": "4.0.7",
@@ -4371,11 +4864,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ]
-    },
-    "node_modules/capability": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/capability/-/capability-0.2.5.tgz",
-      "integrity": "sha512-rsJZYVCgXd08sPqwmaIqjAd5SUTfonV0z/gDJ8D6cN8wQphky1kkAYEqQ+hmDxTw7UihvBfjUVUSY+DBEe44jg=="
     },
     "node_modules/chai": {
       "version": "4.3.7",
@@ -4487,9 +4975,9 @@
       }
     },
     "node_modules/cli-spinners": {
-      "version": "2.7.0",
-      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.7.0.tgz",
-      "integrity": "sha512-qu3pN8Y3qHNgE2AFweciB1IfMnmZ/fsNTEE+NOFjmGB2F/7rLhnhzppvpCnN4FovtP26k8lHyy9ptEbNwWFLzw==",
+      "version": "2.9.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-2.9.2.tgz",
+      "integrity": "sha512-ywqV+5MmyL4E7ybXgKys4DugZbX0FC6LnwrhjuykIjnK9k8OQacQ7axGKnjDXWNhns0xot3bZI5h55H8yo9cJg==",
       "engines": {
         "node": ">=6"
       },
@@ -4543,6 +5031,17 @@
       "version": "2.0.19",
       "resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
       "integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ=="
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/commander": {
       "version": "8.3.0",
@@ -4704,11 +5203,11 @@
       }
     },
     "node_modules/cross-fetch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.5.tgz",
-      "integrity": "sha512-lvb1SBsI0Z7GDwmuid+mU3kWVBwTVUbe7S0H52yaaAdQOXq2YktTCZdlAcNKFzE6QtRz0snpw9bNiPeOIkkQvw==",
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/cross-fetch/-/cross-fetch-3.1.8.tgz",
+      "integrity": "sha512-cvA+JwZoU0Xq+h6WkMvAUqPEYy92Obet6UdKLfW60qn99ftItKjB5T+BkyWOFWe2pUyfQ+IJHmpOTznqk1M6Kg==",
       "dependencies": {
-        "node-fetch": "2.6.7"
+        "node-fetch": "^2.6.12"
       }
     },
     "node_modules/cross-spawn": {
@@ -4725,9 +5224,9 @@
       }
     },
     "node_modules/crypto-js": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-3.3.0.tgz",
-      "integrity": "sha512-DIT51nX0dCfKltpRiXV+/TVZq+Qq2NgF4644+K7Ttnla7zEzqc+kjJyiB96BHNyUTBxyjzRcZYpUdZa+QAqi6Q=="
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/crypto-js/-/crypto-js-4.2.0.tgz",
+      "integrity": "sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q=="
     },
     "node_modules/css-loader": {
       "version": "6.8.1",
@@ -4827,33 +5326,33 @@
       "integrity": "sha512-I7K1Uu0MBPzaFKg4nI5Q7Vs2t+3gWWW648spaF+Rg7pI9ds18Ugn+lvg4SHczUdKlHI5LWBXyqfS8+DufyBsgQ=="
     },
     "node_modules/csv": {
-      "version": "6.2.8",
-      "resolved": "https://registry.npmjs.org/csv/-/csv-6.2.8.tgz",
-      "integrity": "sha512-QGemEqFr5XgbHcufWwO+qnReFhClbd+6WywKDVqEXmRfGrJHl5fRrlphZUnsky2YAwcCxYJJilPUfaWbuBMfWA==",
+      "version": "5.5.3",
+      "resolved": "https://registry.npmjs.org/csv/-/csv-5.5.3.tgz",
+      "integrity": "sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==",
       "dependencies": {
-        "csv-generate": "^4.2.2",
-        "csv-parse": "^5.3.6",
-        "csv-stringify": "^6.3.0",
-        "stream-transform": "^3.2.2"
+        "csv-generate": "^3.4.3",
+        "csv-parse": "^4.16.3",
+        "csv-stringify": "^5.6.5",
+        "stream-transform": "^2.1.3"
       },
       "engines": {
         "node": ">= 0.1.90"
       }
     },
     "node_modules/csv-generate": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-4.2.2.tgz",
-      "integrity": "sha512-Ah/NcMxHMqwQsuL173yp8EOzHrbLh8iyScqTy990b+TJZNjHhy7gs5FfSmyQ2arLC2QVrueO3DYJVQnibJB3WQ=="
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/csv-generate/-/csv-generate-3.4.3.tgz",
+      "integrity": "sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw=="
     },
     "node_modules/csv-parse": {
-      "version": "5.3.6",
-      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-5.3.6.tgz",
-      "integrity": "sha512-WI330GjCuEioK/ii8HM2YE/eV+ynpeLvU+RXw4R8bRU8R0laK5zO3fDsc4gH8s472e3Ga38rbIjCAiQh+tEHkw=="
+      "version": "4.16.3",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.16.3.tgz",
+      "integrity": "sha512-cO1I/zmz4w2dcKHVvpCr7JVRu8/FymG5OEpmvsZYlccYolPBLoVGKUHgNoc4ZGkFeFlWGEDmMyBM+TTqRdW/wg=="
     },
     "node_modules/csv-stringify": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-6.3.0.tgz",
-      "integrity": "sha512-kTnnBkkLmAR1G409aUdShppWUClNbBQZXhrKrXzKYBGw4yfROspiFvVmjbKonCrdGfwnqwMXKLQG7ej7K/jwjg=="
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/csv-stringify/-/csv-stringify-5.6.5.tgz",
+      "integrity": "sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A=="
     },
     "node_modules/debug": {
       "version": "4.3.4",
@@ -4921,6 +5420,14 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/depd": {
@@ -5140,16 +5647,6 @@
         "node": ">=4"
       }
     },
-    "node_modules/error-polyfill": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/error-polyfill/-/error-polyfill-0.1.3.tgz",
-      "integrity": "sha512-XHJk60ufE+TG/ydwp4lilOog549iiQF2OAPhkk9DdiYWMrltz5yhDz/xnKuenNwP7gy3dsibssO5QpVhkrSzzg==",
-      "dependencies": {
-        "capability": "^0.2.5",
-        "o3": "^1.0.3",
-        "u3": "^0.1.1"
-      }
-    },
     "node_modules/es-module-lexer": {
       "version": "0.9.3",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-0.9.3.tgz",
@@ -5250,95 +5747,56 @@
       }
     },
     "node_modules/ethereum-bloom-filters": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.0.10.tgz",
-      "integrity": "sha512-rxJ5OFN3RwjQxDcFP2Z5+Q9ho4eIdEmSc2ht0fCu8Se9nbXjZ7/031uXoUYJ87KHCOdVeiUuwSnoS7hmYAGVHA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/ethereum-bloom-filters/-/ethereum-bloom-filters-1.1.0.tgz",
+      "integrity": "sha512-J1gDRkLpuGNvWYzWslBQR9cDV4nd4kfvVTE/Wy4Kkm4yb3EYRSlyi0eB/inTsSTTVyA0+HyzHgbr95Fn/Z1fSw==",
       "dependencies": {
-        "js-sha3": "^0.8.0"
+        "@noble/hashes": "^1.4.0"
+      }
+    },
+    "node_modules/ethereum-bloom-filters/node_modules/@noble/hashes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.4.0.tgz",
+      "integrity": "sha512-V1JJ1WTRUqHHrOSh597hURcMqVKVGL/ea3kv0gSnEdsEZ0/+VyPghM1lMNGc00z7CIQorSvbKpuJkxvuHbvdbg==",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethereum-cryptography": {
-      "version": "0.1.3",
-      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-0.1.3.tgz",
-      "integrity": "sha512-w8/4x1SGGzc+tO97TASLja6SLd3fRIK2tLVcV2Gx4IB21hE19atll5Cq9o3d0ZmAYC/8aw0ipieTSiekAea4SQ==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ethereum-cryptography/-/ethereum-cryptography-2.1.3.tgz",
+      "integrity": "sha512-BlwbIL7/P45W8FGW2r7LGuvoEZ+7PWsniMvQ4p5s2xCyw9tmaDlpfsN9HjAucbF+t/qpVHwZUisgfK24TCW8aA==",
       "dependencies": {
-        "@types/pbkdf2": "^3.0.0",
-        "@types/secp256k1": "^4.0.1",
-        "blakejs": "^1.1.0",
-        "browserify-aes": "^1.2.0",
-        "bs58check": "^2.1.2",
-        "create-hash": "^1.2.0",
-        "create-hmac": "^1.1.7",
-        "hash.js": "^1.1.7",
-        "keccak": "^3.0.0",
-        "pbkdf2": "^3.0.17",
-        "randombytes": "^2.1.0",
-        "safe-buffer": "^5.1.2",
-        "scrypt-js": "^3.0.0",
-        "secp256k1": "^4.0.1",
-        "setimmediate": "^1.0.5"
+        "@noble/curves": "1.3.0",
+        "@noble/hashes": "1.3.3",
+        "@scure/bip32": "1.3.3",
+        "@scure/bip39": "1.2.2"
       }
     },
-    "node_modules/ethereumjs-util": {
-      "version": "7.1.5",
-      "resolved": "https://registry.npmjs.org/ethereumjs-util/-/ethereumjs-util-7.1.5.tgz",
-      "integrity": "sha512-SDl5kKrQAudFBUe5OJM9Ac6WmMyYmXX/6sTmLZ3ffG2eY6ZIGBes3pEDxNN6V72WyOw4CPD5RomKdsa8DAAwLg==",
+    "node_modules/ethereum-cryptography/node_modules/@noble/curves": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.3.0.tgz",
+      "integrity": "sha512-t01iSXPuN+Eqzb4eBX0S5oubSqXbK/xXa1Ne18Hj8f9pStxztHCE2gfboSp/dZRLSqfuLpRK2nDXDK+W9puocA==",
       "dependencies": {
-        "@types/bn.js": "^5.1.0",
-        "bn.js": "^5.1.2",
-        "create-hash": "^1.1.2",
-        "ethereum-cryptography": "^0.1.3",
-        "rlp": "^2.2.4"
+        "@noble/hashes": "1.3.3"
       },
-      "engines": {
-        "node": ">=10.0.0"
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
-    "node_modules/ethers": {
-      "version": "5.7.2",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.7.2.tgz",
-      "integrity": "sha512-wswUsmWo1aOK8rR7DIKiWSw9DbLWe6x98Jrn8wcTflTVvaXhAMaB5zGAXy0GYQEQp9iO1iSHWVyARQm11zUtyg==",
-      "funding": [
-        {
-          "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
-        },
-        {
-          "type": "individual",
-          "url": "https://www.buymeacoffee.com/ricmoo"
-        }
-      ],
+    "node_modules/ethereum-cryptography/node_modules/@scure/bip39": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@scure/bip39/-/bip39-1.2.2.tgz",
+      "integrity": "sha512-HYf9TUXG80beW+hGAt3TRM8wU6pQoYur9iNypTROm42dorCGmLnFe3eWjz3gOq6G62H2WRh0FCzAR1PI+29zIA==",
       "dependencies": {
-        "@ethersproject/abi": "5.7.0",
-        "@ethersproject/abstract-provider": "5.7.0",
-        "@ethersproject/abstract-signer": "5.7.0",
-        "@ethersproject/address": "5.7.0",
-        "@ethersproject/base64": "5.7.0",
-        "@ethersproject/basex": "5.7.0",
-        "@ethersproject/bignumber": "5.7.0",
-        "@ethersproject/bytes": "5.7.0",
-        "@ethersproject/constants": "5.7.0",
-        "@ethersproject/contracts": "5.7.0",
-        "@ethersproject/hash": "5.7.0",
-        "@ethersproject/hdnode": "5.7.0",
-        "@ethersproject/json-wallets": "5.7.0",
-        "@ethersproject/keccak256": "5.7.0",
-        "@ethersproject/logger": "5.7.0",
-        "@ethersproject/networks": "5.7.1",
-        "@ethersproject/pbkdf2": "5.7.0",
-        "@ethersproject/properties": "5.7.0",
-        "@ethersproject/providers": "5.7.2",
-        "@ethersproject/random": "5.7.0",
-        "@ethersproject/rlp": "5.7.0",
-        "@ethersproject/sha2": "5.7.0",
-        "@ethersproject/signing-key": "5.7.0",
-        "@ethersproject/solidity": "5.7.0",
-        "@ethersproject/strings": "5.7.0",
-        "@ethersproject/transactions": "5.7.0",
-        "@ethersproject/units": "5.7.0",
-        "@ethersproject/wallet": "5.7.0",
-        "@ethersproject/web": "5.7.1",
-        "@ethersproject/wordlists": "5.7.0"
+        "@noble/hashes": "~1.3.2",
+        "@scure/base": "~1.1.4"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/ethjs-unit": {
@@ -5373,15 +5831,6 @@
         "node": ">=0.8.x"
       }
     },
-    "node_modules/evp_bytestokey": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
-      "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dependencies": {
-        "md5.js": "^1.3.4",
-        "safe-buffer": "^5.1.1"
-      }
-    },
     "node_modules/execa": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -5407,7 +5856,8 @@
     "node_modules/exponential-backoff": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/exponential-backoff/-/exponential-backoff-3.1.1.tgz",
-      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw=="
+      "integrity": "sha512-dX7e/LHVJ6W3DE1MHWi9S1EYzDESENfLrYohG2G++ovZrYOkm4Knwa0mc1cn84xJOR4KEU0WSchhLbd0UklbHw==",
+      "optional": true
     },
     "node_modules/express": {
       "version": "4.18.2",
@@ -5506,6 +5956,12 @@
       "engines": {
         "node": ">= 4.9.1"
       }
+    },
+    "node_modules/fastestsmallesttextencoderdecoder": {
+      "version": "1.0.22",
+      "resolved": "https://registry.npmjs.org/fastestsmallesttextencoderdecoder/-/fastestsmallesttextencoderdecoder-1.0.22.tgz",
+      "integrity": "sha512-Pb8d48e+oIuY4MaM64Cd7OW1gt4nxCHs7/ddPPZ/Ic3sg8yVGM7O9wDvZ7us6ScaUupzM+pfBolwtYhN1IxBIw==",
+      "peer": true
     },
     "node_modules/faye-websocket": {
       "version": "0.11.4",
@@ -5643,9 +6099,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
-      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "version": "1.15.6",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.6.tgz",
+      "integrity": "sha512-wWN62YITEaOpSK584EZXJafH1AGpO8RVgElfkuXbTOrPX4fIfOyEpW/CsiNd8JdYrAoOvafRTOEnvsO++qCqFA==",
       "funding": [
         {
           "type": "individual",
@@ -5659,6 +6115,19 @@
         "debug": {
           "optional": true
         }
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/forwarded": {
@@ -6142,9 +6611,9 @@
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "node_modules/inquirer": {
-      "version": "8.2.5",
-      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.5.tgz",
-      "integrity": "sha512-QAgPDQMEgrDssk1XiwwHoOGYF9BAbUcc1+j+FhEvaOt8/cKRqyLn0U5qA6F74fGhTMGxf92pOvPBeh29jQJDTQ==",
+      "version": "8.2.6",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-8.2.6.tgz",
+      "integrity": "sha512-M1WuAmb7pn9zdFRtQYk26ZBoY043Sse0wVDdk4Bppr+JOXyQYybdtvK+l9wUibhtjdjvtoiNy8tk+EgsYIUqKg==",
       "dependencies": {
         "ansi-escapes": "^4.2.1",
         "chalk": "^4.1.1",
@@ -6160,7 +6629,7 @@
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6",
-        "wrap-ansi": "^7.0.0"
+        "wrap-ansi": "^6.0.1"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -6598,9 +7067,9 @@
       }
     },
     "node_modules/keccak": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.3.tgz",
-      "integrity": "sha512-JZrLIAJWuZxKbCilMpNz5Vj7Vtb4scDG3dMXLOsbzBmQGyjwE61BbW7bJkfKKCShXiQZt3T6sBgALRtmd+nZaQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/keccak/-/keccak-3.0.4.tgz",
+      "integrity": "sha512-3vKuW0jV8J3XNTzvfyicFR5qvxrSAGl7KIhvgOu5cmWwM7tZRj3fMbj/pfIf4be7aznbc+prBWGjywox/g2Y6Q==",
       "hasInstallScript": true,
       "dependencies": {
         "node-addon-api": "^2.0.0",
@@ -6865,13 +7334,13 @@
       "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
     },
     "node_modules/merkletreejs": {
-      "version": "0.2.32",
-      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.2.32.tgz",
-      "integrity": "sha512-TostQBiwYRIwSE5++jGmacu3ODcKAgqb0Y/pnIohXS7sWxh1gCkSptbmF1a43faehRDpcHf7J/kv0Ml2D/zblQ==",
+      "version": "0.3.11",
+      "resolved": "https://registry.npmjs.org/merkletreejs/-/merkletreejs-0.3.11.tgz",
+      "integrity": "sha512-LJKTl4iVNTndhL+3Uz/tfkjD0klIWsHlUzgtuNnNrsf7bAlXR30m+xYB7lHr5Z/l6e/yAIsr26Dabx6Buo4VGQ==",
       "dependencies": {
         "bignumber.js": "^9.0.1",
         "buffer-reverse": "^1.0.1",
-        "crypto-js": "^3.1.9-1",
+        "crypto-js": "^4.2.0",
         "treeify": "^1.1.0",
         "web3-utils": "^1.3.4"
       },
@@ -6886,6 +7355,11 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/micro-ftch": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/micro-ftch/-/micro-ftch-0.3.1.tgz",
+      "integrity": "sha512-/0LLxhzP0tfiR5hcQebtudP56gUurs2CLkGarnCiB/OqEyUFQ6U3paQi/tgLv0hBJYt2rnr9MNpxz4fiiugstg=="
     },
     "node_modules/micromatch": {
       "version": "4.0.5",
@@ -6958,6 +7432,14 @@
         "node": "*"
       }
     },
+    "node_modules/mixme": {
+      "version": "0.5.10",
+      "resolved": "https://registry.npmjs.org/mixme/-/mixme-0.5.10.tgz",
+      "integrity": "sha512-5H76ANWinB1H3twpJ6JY8uvAtpmFvHNArpilJAjXRKXSDDLPIMoZArw5SH0q9z+lLs8IrMw7Q2VWpWimFKFT1Q==",
+      "engines": {
+        "node": ">= 8.0.0"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -6993,6 +7475,7 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true,
       "dependencies": {
         "once": "^1.4.0",
         "readable-stream": "^3.6.0"
@@ -7026,70 +7509,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/near-api-js": {
-      "version": "0.44.2",
-      "resolved": "https://registry.npmjs.org/near-api-js/-/near-api-js-0.44.2.tgz",
-      "integrity": "sha512-eMnc4V+geggapEUa3nU2p8HSHn/njtloI4P2mceHQWO8vDE1NGpnAw8FuTBrLmXSgIv9m6oocgFc9t3VNf5zwg==",
-      "dependencies": {
-        "bn.js": "5.2.0",
-        "borsh": "^0.6.0",
-        "bs58": "^4.0.0",
-        "depd": "^2.0.0",
-        "error-polyfill": "^0.1.3",
-        "http-errors": "^1.7.2",
-        "js-sha256": "^0.9.0",
-        "mustache": "^4.0.0",
-        "node-fetch": "^2.6.1",
-        "text-encoding-utf-8": "^1.0.2",
-        "tweetnacl": "^1.0.1"
-      }
-    },
-    "node_modules/near-api-js/node_modules/bn.js": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.2.0.tgz",
-      "integrity": "sha512-D7iWRBvnZE8ecXiLj/9wbxH7Tk79fAh8IHaTNq1RWRixsS02W+5qS+iE9yq6RYl0asXx5tw0bLhmT5pIfbSquw=="
-    },
-    "node_modules/near-api-js/node_modules/borsh": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/borsh/-/borsh-0.6.0.tgz",
-      "integrity": "sha512-sl5k89ViqsThXQpYa9XDtz1sBl3l1lI313cFUY1HKr+wvMILnb+58xpkqTNrYbelh99dY7K8usxoCusQmqix9Q==",
-      "dependencies": {
-        "bn.js": "^5.2.0",
-        "bs58": "^4.0.0",
-        "text-encoding-utf-8": "^1.0.2"
-      }
-    },
-    "node_modules/near-api-js/node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
-      "dependencies": {
-        "depd": "~1.1.2",
-        "inherits": "2.0.4",
-        "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
-        "toidentifier": "1.0.1"
-      },
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/near-api-js/node_modules/http-errors/node_modules/depd": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/depd/-/depd-1.1.2.tgz",
-      "integrity": "sha512-7emPTl6Dpo6JRXOXjLRxck+FlLRX5847cLKEn00PLAgc3g2hTZZgr+e4c2v6QpSmLeFP3n5yUo7ft6avBK/5jQ==",
-      "engines": {
-        "node": ">= 0.6"
-      }
-    },
-    "node_modules/near-api-js/node_modules/statuses": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
-      "integrity": "sha512-OpZ3zP+jT1PI7I8nemJX4AKmAX070ZkYPVWV/AaKTJl+tXCTGyVdC1a4SL8RUQYEwk/f34ZX8UTykN68FwrqAA==",
-      "engines": {
-        "node": ">= 0.6"
       }
     },
     "node_modules/near-hd-key": {
@@ -7142,9 +7561,9 @@
       "integrity": "sha512-Ntyt4AIXyaLIuMHF6IOoTakB3K+RWxwtsHNRxllEoA6vPwP9o4866g6YWDLUdnucilZhmkxiHwHr11gAENw+QA=="
     },
     "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
       "dependencies": {
         "whatwg-url": "^5.0.0"
       },
@@ -7287,14 +7706,6 @@
       "version": "4.11.6",
       "resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.6.tgz",
       "integrity": "sha512-XWwnNNFCuuSQ0m3r3C4LE3EiORltHd9M05pq6FOlVeiophzRbMo50Sbz1ehl8K3Z+jw9+vmgnXefY1hz8X+2wA=="
-    },
-    "node_modules/o3": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/o3/-/o3-1.0.3.tgz",
-      "integrity": "sha512-f+4n+vC6s4ysy7YO7O2gslWZBUu8Qj2i2OUJOvjRxQva7jVjYjB29jrr9NCjmxZQR0gzrOcv1RnqoYOeMs5VRQ==",
-      "dependencies": {
-        "capability": "^0.2.5"
-      }
     },
     "node_modules/object-inspect": {
       "version": "1.12.3",
@@ -7766,6 +8177,11 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
+    },
     "node_modules/pstree.remy": {
       "version": "1.1.8",
       "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
@@ -8056,23 +8472,11 @@
         "inherits": "^2.0.1"
       }
     },
-    "node_modules/rlp": {
-      "version": "2.2.7",
-      "resolved": "https://registry.npmjs.org/rlp/-/rlp-2.2.7.tgz",
-      "integrity": "sha512-d5gdPmgQ0Z+AklL2NVXr/IoSjNZFfTVvQWzL/AM2AOcSzYP2xjlb0AC8YyCLc41MSNf6P6QVtjgPdmVtzb+4lQ==",
-      "dependencies": {
-        "bn.js": "^5.2.0"
-      },
-      "bin": {
-        "rlp": "bin/rlp"
-      }
-    },
     "node_modules/rpc-websockets": {
-      "version": "7.5.1",
-      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.5.1.tgz",
-      "integrity": "sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==",
+      "version": "7.11.0",
+      "resolved": "https://registry.npmjs.org/rpc-websockets/-/rpc-websockets-7.11.0.tgz",
+      "integrity": "sha512-IkLYjayPv6Io8C/TdCL5gwgzd1hFz2vmBZrjMw/SPEXo51ETOhnzgS4Qy5GWi2JQN7HKHa66J3+2mv0fgNh/7w==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
         "eventemitter3": "^4.0.7",
         "uuid": "^8.3.2",
         "ws": "^8.5.0"
@@ -8095,9 +8499,9 @@
       }
     },
     "node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dependencies": {
         "tslib": "^2.1.0"
       }
@@ -8157,18 +8561,23 @@
       "integrity": "sha512-cdwTTnqPu0Hyvf5in5asVdZocVDTNRmR7XEcJuIzMjJeSHybHl7vpB66AzwTaIg6CLSbtjcxc8fqcySfnTkccA=="
     },
     "node_modules/secp256k1": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-4.0.3.tgz",
-      "integrity": "sha512-NLZVf+ROMxwtEj3Xa562qgv2BK5e2WNmXPiOdVIPLgs6lyTzMvBq0aWTYMI5XCP9jZMVKOcqZLw/Wc4vDkuxhA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/secp256k1/-/secp256k1-5.0.0.tgz",
+      "integrity": "sha512-TKWX8xvoGHrxVdqbYeZM9w+izTF4b9z3NhSaDkdn81btvuh+ivbIMGT/zQvDtTFWhRlThpoz6LEYTr7n8A5GcA==",
       "hasInstallScript": true,
       "dependencies": {
         "elliptic": "^6.5.4",
-        "node-addon-api": "^2.0.0",
+        "node-addon-api": "^5.0.0",
         "node-gyp-build": "^4.2.0"
       },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=14.0.0"
       }
+    },
+    "node_modules/secp256k1/node_modules/node-addon-api": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-5.1.0.tgz",
+      "integrity": "sha512-eh0GgfEkpnoWDq+VY8OyvYhFEzBk6jIYbRKdIlyTiAXIVJ8PyBaKb0rp7oDtoddbdoHWhq8wwr+XZ81F1rpNdA=="
     },
     "node_modules/select-hose": {
       "version": "2.0.0",
@@ -8327,11 +8736,6 @@
       "engines": {
         "node": ">= 0.8.0"
       }
-    },
-    "node_modules/setimmediate": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/setimmediate/-/setimmediate-1.0.5.tgz",
-      "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA=="
     },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
@@ -8497,9 +8901,12 @@
       }
     },
     "node_modules/stream-transform": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-3.2.2.tgz",
-      "integrity": "sha512-DHZQPNxvjU2qdQlGcpitn8pkJHQVTqdshtgXaLz6Vc5VCAognbGuuwGS5ugeqGVnyw8j4h89QcV8cwm0D1+V0A=="
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/stream-transform/-/stream-transform-2.1.3.tgz",
+      "integrity": "sha512-9GHUiM5hMiCi6Y03jD2ARC1ettBXkQBoQAe7nJsPknnI0ow10aXjTnew8QtYQmLjzn974BnmWEAJgCY6ZP1DeQ==",
+      "dependencies": {
+        "mixme": "^0.5.1"
+      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -8707,19 +9114,18 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/tmp-promise/-/tmp-promise-3.0.3.tgz",
       "integrity": "sha512-RwM7MoPojPxsOBYnyd2hy0bxtIlVrihNs9pj5SUvY8Zz1sQcQG2tG1hSr8PDxfgEB8RNKDhqbIlroIarSNDNsQ==",
+      "optional": true,
       "dependencies": {
         "tmp": "^0.2.0"
       }
     },
     "node_modules/tmp-promise/node_modules/tmp": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.1.tgz",
-      "integrity": "sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==",
-      "dependencies": {
-        "rimraf": "^3.0.0"
-      },
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.3.tgz",
+      "integrity": "sha512-nZD7m9iCPC5g0pYmcaxogYKggSfLsdxl8of3Q/oIbqCqLLIO9IAF0GWjX1z9NZRHPiXv8Wex4yDCaZsgEw0Y8w==",
+      "optional": true,
       "engines": {
-        "node": ">=8.17.0"
+        "node": ">=14.14"
       }
     },
     "node_modules/to-fast-properties": {
@@ -8943,11 +9349,6 @@
       "resolved": "https://registry.npmjs.org/typescript-collections/-/typescript-collections-1.3.3.tgz",
       "integrity": "sha512-7sI4e/bZijOzyURng88oOFZCISQPTHozfE2sUu5AviFYk5QV7fYGb6YiDl+vKjF/pICA354JImBImL9XJWUvdQ=="
     },
-    "node_modules/u3": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/u3/-/u3-0.1.1.tgz",
-      "integrity": "sha512-+J5D5ir763y+Am/QY6hXNRlwljIeRMZMGs0cT6qqZVVzzT3X3nFPXVyPOFRMOR4kupB0T8JnCdpWdp6Q/iXn3w=="
-    },
     "node_modules/undefsafe": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
@@ -9121,13 +9522,14 @@
       }
     },
     "node_modules/web3-utils": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.8.2.tgz",
-      "integrity": "sha512-v7j6xhfLQfY7xQDrUP0BKbaNrmZ2/+egbqP9q3KYmOiPpnvAfol+32slgL0WX/5n8VPvKCK5EZ1HGrAVICSToA==",
+      "version": "1.10.4",
+      "resolved": "https://registry.npmjs.org/web3-utils/-/web3-utils-1.10.4.tgz",
+      "integrity": "sha512-tsu8FiKJLk2PzhDl9fXbGUWTkkVXYhtTA+SmEFkKft+9BgwLxfCRpU96sWv7ICC8zixBNd3JURVoiR3dUXgP8A==",
       "dependencies": {
+        "@ethereumjs/util": "^8.1.0",
         "bn.js": "^5.2.1",
         "ethereum-bloom-filters": "^1.0.6",
-        "ethereumjs-util": "^7.1.0",
+        "ethereum-cryptography": "^2.1.2",
         "ethjs-unit": "0.1.6",
         "number-to-bn": "1.7.0",
         "randombytes": "^2.1.0",
@@ -9526,19 +9928,16 @@
       "integrity": "sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw=="
     },
     "node_modules/wrap-ansi": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
-      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-6.2.0.tgz",
+      "integrity": "sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==",
       "dependencies": {
         "ansi-styles": "^4.0.0",
         "string-width": "^4.1.0",
         "strip-ansi": "^6.0.0"
       },
       "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+        "node": ">=8"
       }
     },
     "node_modules/wrap-ansi/node_modules/ansi-styles": {

--- a/package.json
+++ b/package.json
@@ -9,12 +9,12 @@
   "author": "Shaun Hamilton",
   "type": "module",
   "dependencies": {
-    "@babel/parser": "7.23.0",
+    "@babel/parser": "7.24.5",
     "@freecodecamp/freecodecamp-os": "1.10.0",
-    "@metaplex-foundation/js": "0.19.3",
-    "@solana/spl-token": "0.3.7",
-    "@solana/web3.js": "1.87.7",
+    "@metaplex-foundation/js": "0.20.1",
+    "@solana/spl-token": "0.4.6",
+    "@solana/web3.js": "1.91.8",
     "babeliser": "0.6.0",
-    "borsh": "0.7.0"
+    "borsh": "2.0.0"
   }
 }


### PR DESCRIPTION
Closes #331 
Closes #340 
Closes #339 
Closes #341 


For those wondering, the crates `solana-*` need to have their version match the CLI version. This is painful, and odd, because minor changes cause programs to fail to compile.