### PR TITLE
fix: use new bpf loader in rpc call

### DIFF
--- a/curriculum/locales/english/build-a-university-certification-nft.md
+++ b/curriculum/locales/english/build-a-university-certification-nft.md
@@ -75,7 +75,7 @@ const command = `curl http://127.0.0.1:8899 -X POST -H "Content-Type: applicatio
     "id": 1,
     "method": "getProgramAccounts",
     "params": [
-      "BPFLoader2111111111111111111111111111111111", {
+      "BPFLoaderUpgradeab1e11111111111111111111111", {
         "encoding": "base64",
         "dataSlice": {
           "length": 0,


### PR DESCRIPTION
The old CLI command "solana deploy" uses the BPFLoader2111111111111111111111111111111111 loader, however the newer command "solana program deploy" uses the BPFLoaderUpgradeab1e11111111111111111111111 loader instead.

https://stackoverflow.com/questions/69884904/difference-bewteen-solana-deploy-and-solana-program-deploy

Checklist:

<!-- Please follow this checklist and put an x in each of the boxes, like this: [x]. It will ensure that our team takes your pull request seriously. -->

- [x] I have read [freeCodeCamp's contribution guidelines](https://contribute.freecodecamp.org).
- [x] My pull request has a [descriptive title](https://contribute.freecodecamp.org/#/how-to-open-a-pull-request?id=prepare-a-good-pr-title) (**not** a vague title like `Update index.md`)

<!--If your pull request closes a GitHub issue, replace the XXXXX below with the issue number.-->

Closes #XXXXX

<!-- Feel free to add any additional description of changes below this line -->
